### PR TITLE
Implementation of SSI Mighty mini pump control

### DIFF
--- a/pumpy.py
+++ b/pumpy.py
@@ -264,7 +264,7 @@ class MightyMini():
         self.name = name
         self.serialcon = chain.serialcon
 
-        logging.info('Pump %s: created at address %s on %s',self.name,self.address,self.serialcon.port)
+        logging.info('Pump %s: created on %s',self.name,self.serialcon.port)
 
     def __repr__(self):
         string = ''
@@ -334,7 +334,7 @@ class MightyMini():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Command line interface to pumpy module for control of Harvard Pump 11 (default) or PHD2000 syringe pumps, or SSI Mighty Mini Pump')
     parser.add_argument('port',help='serial port')
-    parser.add_argument('address',help='pump address (Harvard pumps)',type=int,nargs='?',default="00")
+    parser.add_argument('address',help='pump address (Harvard pumps)',type=int,nargs='?',default=0)
     parser.add_argument('-d',dest='diameter',help='set syringe diameter',type=int)
     parser.add_argument('-f',dest='flowrate',help='set flow rate')
     parser.add_argument('-t',dest='targetvolume',help='set target volume')


### PR DESCRIPTION
Allows control of Mighty Mini pump with pumpy:
- Added optional stopbits argument to Chain constructor. Allows one stopbit to be used for Mighty Mini pump.
- MightyMini class implements all Pump functions for this pump. `setdiameter`, `withdraw`, `settargetvolume` and `waituntiltarget` are no-ops as they cannot be implemented for this pump.
- New commandline switch `-MightyMini` to enable this pump.
